### PR TITLE
Pass custom site

### DIFF
--- a/modules/record-sync.js
+++ b/modules/record-sync.js
@@ -101,6 +101,7 @@ async function unpackSyncConfig(syncConfig, options) {
 		syncConfig.variables = {
 			section: syncConfig.section || syncConfig.name,
 			type: syncConfig.type,
+			site: syncConfig.site || process.env.CMS_SITE
 		}
 	}
 


### PR DESCRIPTION
@weotch This is a change I would like to have... let me explain:

Sendbird has the unique case of 1 site with multiple langs. I need to sync to multiple indicies from one site. In a normal project, each lang is set by the CMS_SITE env var in a dedicated netlify site, but not here for sendbird. 

My change is allowing you to pass the site variable from cloak config, so IF it exists, it will use that, and then, in my config, it looks something like this: 

```
algolia: {
	sync: [
		{
			name: 'blog',
			indexName: 'prod_en_US_blog',
			fragmentPath: 'queries/fragments/blog.gql',
			section: 'blogs',
			type: 'blog',
			site: 'en_US'
		},
		{
			name: 'blog',
			indexName: 'prod_ko_KR_blog',
			fragmentPath: 'queries/fragments/blog.gql',
			section: 'blogs',
			type: 'blog',
			site: 'ko_KR'
		}
	]
}
```

Mayne an opportunity to dry that up, but I've tested this with the proposed change, and it synced the correct site entries to the correct index